### PR TITLE
Allows some plugins to be functionnal

### DIFF
--- a/lv2/ttl/coilcrafter.ttl
+++ b/lv2/ttl/coilcrafter.ttl
@@ -97,7 +97,7 @@
                 lv2:symbol "F2" ;
                 lv2:name "Destination Pickup Frequency" ;
                 lv2:default 2600 ;
-                lv2:minimum 2600
+                lv2:minimum 2600 ;
                 lv2:maximum 4500 ;
                 lv2:portProperty lv2:integer ;
                 units:unit units:hz ;

--- a/lv2/ttl/distband.ttl
+++ b/lv2/ttl/distband.ttl
@@ -230,7 +230,7 @@
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 13 ;
                 lv2:symbol "LVOL" ;
-                lv2:name "Low Gain"
+                lv2:name "Low Gain" ;
                 lv2:default 50 ;
                 lv2:minimum 0 ;
                 lv2:maximum 100 ;
@@ -239,7 +239,7 @@
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 14 ;
                 lv2:symbol "MVOL" ;
-                lv2:name "Mid Gain"
+                lv2:name "Mid Gain" ;
                 lv2:default 14 ;
                 lv2:minimum 0 ;
                 lv2:maximum 100 ;
@@ -248,7 +248,7 @@
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 15 ;
                 lv2:symbol "HVOL" ;
-                lv2:name "High Gain"
+                lv2:name "High Gain" ;
                 lv2:default 35 ;
                 lv2:minimum 0 ;
                 lv2:maximum 100 ;

--- a/lv2/ttl/otrem.ttl
+++ b/lv2/ttl/otrem.ttl
@@ -23,7 +23,7 @@
         lv2:project <http://rakarrack.sourceforge.net/effects.html>;
         lv2:minorVersion 0 ;
         lv2:microVersion 0 ;
-        rdfs:comment "An optical tremolo effect emulation such as often built into a guitar amplifier. This varies the signal volume through an LFO."
+        rdfs:comment "An optical tremolo effect emulation such as often built into a guitar amplifier. This varies the signal volume through an LFO." ;
         lv2:optionalFeature lv2:hardRTCapable ;
 #        ui:ui  <http://rakarrack.sourceforge.net/effects.html#Otrem_ui> ;
 

--- a/lv2/ttl/shelfboost.ttl
+++ b/lv2/ttl/shelfboost.ttl
@@ -95,7 +95,7 @@
                 lv2:symbol "STEREO" ;
                 lv2:name "Stereo" ;
                 lv2:default 1 ;
-                lv2:minimum 0
+                lv2:minimum 0 ;
                 lv2:maximum 1 ;
                 lv2:portProperty lv2:integer ;
                 lv2:portProperty lv2:toggled ;


### PR DESCRIPTION
It does look to be typos which prevents OpticalTrem and ShelfBoost to be launched (tested in jalv.qt).
Please @ssj71 : check that this is right.