### PR TITLE
Newplugs - Add Regular Phaser

### DIFF
--- a/lv2/CMakeLists.txt
+++ b/lv2/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(rkrlv2 SHARED
   ../src/Opticaltrem.C
   ../src/Vibe.C
   ../src/Infinity.C
+  ../src/Phaser.C
 )
 
 set_target_properties(rkrlv2 PROPERTIES PREFIX "")

--- a/lv2/rkrlv2.h
+++ b/lv2/rkrlv2.h
@@ -44,6 +44,7 @@
 #define OPTTREMLV2_URI "http://rakarrack.sourceforge.net/effects.html#Otrem"
 #define VIBELV2_URI "http://rakarrack.sourceforge.net/effects.html#Vibe"
 #define INFLV2_URI "http://rakarrack.sourceforge.net/effects.html#Infinity"
+#define PHASELV2_URI "http://rakarrack.sourceforge.net/effects.html#phas"
 
 #define RVBFILE_URI "http://rakarrack.sourceforge.net/effects.html#Reverbtron:rvbfile"
 #define DLYFILE_URI "http://rakarrack.sourceforge.net/effects.html#Echotron:dlyfile"
@@ -123,7 +124,8 @@ enum RKRLV2_effects_
 	IMBCOMP,
 	IOPTTREM,
 	IVIBE,//40
-	IINF
+	IINF,
+	IPHASE
 };
 
 #endif

--- a/lv2/ttl/manifest.ttl
+++ b/lv2/ttl/manifest.ttl
@@ -222,3 +222,9 @@
         a lv2:Plugin, lv2:ModulatorPlugin ;
         lv2:binary <rkrlv2.so> ;
         rdfs:seeAlso <inf.ttl> .
+
+# 42
+<http://rakarrack.sourceforge.net/effects.html#phas>
+        a lv2:Plugin, lv2:PhaserPlugin ;
+        lv2:binary <rkrlv2.so> ;
+        rdfs:seeAlso <phas.ttl> .

--- a/lv2/ttl/phas.ttl
+++ b/lv2/ttl/phas.ttl
@@ -1,0 +1,222 @@
+@prefix doap:  <http://usefulinc.com/ns/doap#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+@prefix pset: <http://lv2plug.in/ns/ext/presets#> .
+@prefix mod:   <http://moddevices.com/ns/mod#>.
+
+@prefix lv2:   <http://lv2plug.in/ns/lv2core#> .
+@prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
+
+# <http://rakarrack.sourceforge.net/effects.html#phas_ui>
+# 	a ui:X11UI ;
+# 	ui:binary <rkrlv2_ui.so> ;
+# 	lv2:extensionData ui:idleInterface;
+# 	.
+
+<http://rakarrack.sourceforge.net/effects.html#phas>
+        a lv2:Plugin, lv2:PhaserPlugin ;
+        doap:name "rkr Phaser" ;
+        mod:brand "Rakarrack";
+        mod:label "Phaser";
+        doap:description "Phaser";
+        doap:license <http://opensource.org/licenses/GPL-2.0> ;
+        lv2:project <http://rakarrack.sourceforge.net/effects.html>;
+        lv2:minorVersion 0 ;
+        lv2:microVersion 0 ;
+        rdfs:comment "More mild digital phaser with exponential LFO sweep." ;
+        lv2:optionalFeature lv2:hardRTCapable ;
+#        ui:ui  <http://rakarrack.sourceforge.net/effects.html#phas_ui> ;
+
+        lv2:port [
+                a lv2:InputPort, lv2:AudioPort ;
+                lv2:index 0 ;
+                lv2:symbol "INPUT_L" ;
+                lv2:name "Audio In L" ;
+        ] ;
+        lv2:port [
+                a lv2:InputPort, lv2:AudioPort ;
+                lv2:index 1 ;
+                lv2:symbol "INPUT_R" ;
+                lv2:name "Audio In R" ;
+        ] ;
+        lv2:port [
+                a lv2:OutputPort, lv2:AudioPort ;
+                lv2:index 2 ;
+                lv2:symbol "OUTPUT_L" ;
+                lv2:name "Audio Out L" ;
+        ] ;
+        lv2:port [
+                a lv2:OutputPort, lv2:AudioPort ;
+                lv2:index 3 ;
+                lv2:symbol "OUTPUT_R" ;
+                lv2:name "Audio Out R" ;
+        ] ;
+
+        lv2:port [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 4 ;
+                lv2:symbol "BYPASS" ;
+                lv2:name "Bypass" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 1 ;
+                lv2:portProperty lv2:integer ;
+                lv2:portProperty lv2:toggled ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 5 ;
+                lv2:symbol "WETDRY" ;
+                lv2:name "Wet/Dry" ;
+                lv2:default 64 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 6 ;
+                lv2:symbol "PAN" ;
+                lv2:name "Panning" ;
+                lv2:default 0 ;
+                lv2:minimum -64 ;
+                lv2:maximum 63 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 7 ;
+                lv2:symbol "TEMPO" ;
+                lv2:name "Tempo" ;
+                lv2:default 11 ;
+                lv2:minimum 1 ;
+                lv2:maximum 600 ;
+                lv2:portProperty lv2:integer ;
+                units:unit units:bpm ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 8 ;
+                lv2:symbol "RND" ;
+                lv2:name "Randomness" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 9 ;
+                lv2:symbol "TYPE" ;
+                lv2:name "LFO Type" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 11 ;
+                lv2:portProperty lv2:integer ;
+                lv2:portProperty lv2:enumeration;
+                lv2:scalePoint [ rdfs:label "Sine"; rdf:value 0 ] ;
+                lv2:scalePoint [ rdfs:label "Triangle"; rdf:value 1 ] ;
+                lv2:scalePoint [ rdfs:label "Ramp Up"; rdf:value 2 ] ;
+                lv2:scalePoint [ rdfs:label "Ramp Down"; rdf:value 3 ] ;
+                lv2:scalePoint [ rdfs:label "ZigZag"; rdf:value 4 ] ;
+                lv2:scalePoint [ rdfs:label "Modulated Square"; rdf:value 5 ] ;
+                lv2:scalePoint [ rdfs:label "Modulated Saw"; rdf:value 6 ] ;
+                lv2:scalePoint [ rdfs:label "Lorenz Fractal"; rdf:value 7 ] ;
+                lv2:scalePoint [ rdfs:label "Lorenz Fractal XY"; rdf:value 8 ] ;
+                lv2:scalePoint [ rdfs:label "Random Sample and Hold"; rdf:value 9 ] ;
+                lv2:scalePoint [ rdfs:label "Triangle Topped Sine"; rdf:value 10 ] ;
+                lv2:scalePoint [ rdfs:label "Triangle Bottomed Sine"; rdf:value 11 ] ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 10 ;
+                lv2:symbol "STDL" ;
+                lv2:name "LFO L/R Delay" ;
+                lv2:default 64 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 11 ;
+                lv2:symbol "DEPTH" ;
+                lv2:name "Phase Depth" ;
+                lv2:default 110 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 12 ;
+                lv2:symbol "FB" ;
+                lv2:name "Feedback" ;
+                lv2:default 64 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 13 ;
+                lv2:symbol "STAGES" ;
+                lv2:name "Stages" ;
+                lv2:default 1 ;
+                lv2:minimum 1 ;
+                lv2:maximum 12 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 14 ;
+                lv2:symbol "LRCR" ;
+                lv2:name "Left/Right Crossover" ;
+                lv2:default -64 ;
+                lv2:minimum -64 ;
+                lv2:maximum  64 ;
+                lv2:portProperty lv2:integer ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 15 ;
+                lv2:symbol "SUB" ;
+                lv2:name "Subtract" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 1 ;
+                lv2:portProperty lv2:integer ;
+                lv2:portProperty lv2:toggled ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 16 ;
+                lv2:symbol "PHASE" ;
+                lv2:name "Phase" ;
+                lv2:default 20 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+        ] ;
+	.
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_1>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_2>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_3>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_4>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_5>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_6>
+        a pset:Preset ;
+        lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+        rdfs:seeAlso <phas_presets.ttl> .
+

--- a/lv2/ttl/phas_presets.ttl
+++ b/lv2/ttl/phas_presets.ttl
@@ -1,0 +1,260 @@
+@prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
+@prefix pset: <http://lv2plug.in/ns/ext/presets#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix state: <http://lv2plug.in/ns/ext/state#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_1> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 1" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 11.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 110.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 1.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_2> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 2" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 10.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 88.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 40.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 3.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_3> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 3" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 8.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 66.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 68.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 107.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 2.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_4> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 4" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 39.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 1.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 66.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 67.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 10.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 5.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 1.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_5> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 5" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 1.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 1.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 110.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 67.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 78.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 10.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+
+<http://rakarrack.sourceforge.net/effects.html#phas:preset:phaser_6> 
+	a pset:Preset ;
+	lv2:appliesTo <http://rakarrack.sourceforge.net/effects.html#phas> ;
+	rdfs:label "Phaser 6" ;
+	lv2:port [
+		lv2:symbol "WETDRY" ;
+		pset:value 64.0
+	] , [
+		lv2:symbol "PAN" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "TEMPO" ;
+		pset:value 31.0
+	] , [
+		lv2:symbol "RND" ;
+		pset:value 100.0
+	] , [
+		lv2:symbol "TYPE" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "STDL" ;
+		pset:value 58.0
+	] , [
+		lv2:symbol "DEPTH" ;
+		pset:value 37.0
+	] , [
+		lv2:symbol "FB" ;
+		pset:value 78.0
+	] , [
+		lv2:symbol "STAGES" ;
+		pset:value 3.0
+	] , [
+		lv2:symbol "LRCR" ;
+		pset:value -64.0
+	] , [
+		lv2:symbol "SUB" ;
+		pset:value 0.0
+	] , [
+		lv2:symbol "PHASE" ;
+		pset:value 20.0
+	] .
+

--- a/src/Phaser.C
+++ b/src/Phaser.C
@@ -39,7 +39,7 @@ Phaser::Phaser (float * efxoutl_, float * efxoutr_, double sample_rate)
     lfo = new EffectLFO(sample_rate);
 
     Ppreset = 0;
-    PERIOD = 255; //make best guess for init;
+    PERIOD = 256; //best guess until the effect starts running;
     setpreset (Ppreset);
     cleanup ();
 };

--- a/src/Phaser.C
+++ b/src/Phaser.C
@@ -25,9 +25,10 @@
 #include <math.h>
 #include "Phaser.h"
 #include <stdio.h>
+#include "FPreset.h"
 #define PHASER_LFO_SHAPE 2
 
-Phaser::Phaser (float * efxoutl_, float * efxoutr_)
+Phaser::Phaser (float * efxoutl_, float * efxoutr_, double sample_rate)
 {
     efxoutl = efxoutl_;
     efxoutr = efxoutr_;
@@ -35,13 +36,17 @@ Phaser::Phaser (float * efxoutl_, float * efxoutr_)
     oldl = (float *) malloc(sizeof(float)* MAX_PHASER_STAGES * 2);
     oldr = (float *) malloc(sizeof(float)* MAX_PHASER_STAGES * 2);
 
+    lfo = new EffectLFO(sample_rate);
+
     Ppreset = 0;
+    PERIOD = 255; //make best guess for init;
     setpreset (Ppreset);
     cleanup ();
 };
 
 Phaser::~Phaser ()
 {
+	delete lfo;
 };
 
 
@@ -49,12 +54,13 @@ Phaser::~Phaser ()
  * Effect output
  */
 void
-Phaser::out (float * smpsl, float * smpsr)
+Phaser::out (float * smpsl, float * smpsr, uint32_t period)
 {
-    int i, j;
+    unsigned int i;
+    int j;
     float lfol, lfor, lgain, rgain, tmp;
 
-    lfo.effectlfoout (&lfol, &lfor);
+    lfo->effectlfoout (&lfol, &lfor);
     lgain = lfol;
     rgain = lfor;
     lgain =
@@ -76,7 +82,7 @@ Phaser::out (float * smpsl, float * smpsr)
         rgain = 0.0f;
 
     for (i = 0; i < period; i++) {
-        float x = (float) i / fPERIOD;
+        float x = (float) i / float(period);
         float x1 = 1.0f - x;
         float gl = lgain * x + oldlgain * x1;
         float gr = rgain * x + oldrgain * x1;
@@ -179,8 +185,8 @@ Phaser::setlrcross (int Plrcross)
 void
 Phaser::setstages (int Pstages)
 {
-    if (Pstages >= MAX_PHASER_STAGES)
-        Pstages = MAX_PHASER_STAGES - 1;
+    if (Pstages > MAX_PHASER_STAGES)
+        Pstages = MAX_PHASER_STAGES;
     this->Pstages = Pstages;
     cleanup ();
 };
@@ -198,6 +204,7 @@ Phaser::setpreset (int npreset)
 {
     const int PRESET_SIZE = 12;
     const int NUM_PRESETS = 6;
+    int pdata[PRESET_SIZE];
     int presets[NUM_PRESETS][PRESET_SIZE] = {
         //Phaser1
         {64, 64, 11, 0, 0, 64, 110, 64, 1, 0, 0, 20},
@@ -215,7 +222,7 @@ Phaser::setpreset (int npreset)
 
     if(npreset>NUM_PRESETS-1) {
 
-        Fpre->ReadPreset(6,npreset-NUM_PRESETS+1);
+        Fpre->ReadPreset(6,npreset-NUM_PRESETS+1,pdata);
         for (int n = 0; n < PRESET_SIZE; n++)
             changepar (n, pdata[n]);
     } else {
@@ -237,20 +244,20 @@ Phaser::changepar (int npar, int value)
         setpanning (value);
         break;
     case 2:
-        lfo.Pfreq = value;
-        lfo.updateparams ();
+        lfo->Pfreq = value;
+        lfo->updateparams (PERIOD);
         break;
     case 3:
-        lfo.Prandomness = value;
-        lfo.updateparams ();
+        lfo->Prandomness = value;
+        lfo->updateparams (PERIOD);
         break;
     case 4:
-        lfo.PLFOtype = value;
-        lfo.updateparams ();
+        lfo->PLFOtype = value;
+        lfo->updateparams (PERIOD);
         break;
     case 5:
-        lfo.Pstereo = value;
-        lfo.updateparams ();
+        lfo->Pstereo = value;
+        lfo->updateparams (PERIOD);
         break;
     case 6:
         setdepth (value);
@@ -272,7 +279,7 @@ Phaser::changepar (int npar, int value)
     case 11:
         setphase (value);
         break;
-    };
+    }
 };
 
 int
@@ -286,22 +293,22 @@ Phaser::getpar (int npar)
         return (Ppanning);
         break;
     case 2:
-        return (lfo.Pfreq);
+        return (lfo->Pfreq);	// tempo
         break;
     case 3:
-        return (lfo.Prandomness);
+        return (lfo->Prandomness);
         break;
     case 4:
-        return (lfo.PLFOtype);
+        return (lfo->PLFOtype);
         break;
     case 5:
-        return (lfo.Pstereo);
+        return (lfo->Pstereo);	// STDL
         break;
     case 6:
         return (Pdepth);
         break;
     case 7:
-        return (Pfb);
+        return (Pfb);			// pfb feedback
         break;
     case 8:
         return (Pstages);
@@ -317,6 +324,5 @@ Phaser::getpar (int npar)
         break;
     default:
         return (0);
-    };
-
+    }
 };

--- a/src/Phaser.h
+++ b/src/Phaser.h
@@ -30,9 +30,9 @@
 class Phaser
 {
 public:
-    Phaser (float * efxoutl_, float * efxoutr_);
+    Phaser (float * efxoutl_, float * efxoutr_, double sample_rate);
     ~Phaser ();
-    void out (float * smpsl, float * smpsr);
+    void out (float * smpsl, float * smpsr, uint32_t period);
     void setpreset (int npreset);
     void changepar (int npar, int value);
     int getpar (int npar);
@@ -43,10 +43,10 @@ public:
     float *efxoutl;
     float *efxoutr;
 
-
+    uint32_t PERIOD;
+    EffectLFO *lfo;     //Phaser modulator
 
 private:
-
     void setvolume (int Pvolume);
     void setpanning (int Ppanning);
     void setdepth (int Pdepth);
@@ -73,7 +73,6 @@ private:
     float *oldl, *oldr;
     float oldlgain, oldrgain;
 
-    EffectLFO lfo;		//lfo-ul Phaser
     class FPreset *Fpre;
 
 };


### PR DESCRIPTION
Greetings!! Hope this project is still going!

I really like the regular phaser for some effects and could not duplicate the sound to my liking with the analog phaser. So I went ahead and made the conversion myself instead of annoying you :-).

The following may be issues of interest :

- MAX_PHASER_STAGES - I took the liberty of fixing the setstages() function to set the max stages
to 12 vs 11. The original used MAX_PHASER_STAGES (12) minus 1 = 11. This seems wrong since the original rakarrack gui was for 1 to 12 (and rkrlv2). Looks like a start from 0 vs a start from 1 error. Carryover from rakarrack.

The following code was added to rkrlv2.C to fix an intermitant bug that effects several other plugins as well:

- rkrlv2.C -- new variable in: typedef struct _RKRLV2{}
    uint8_t init_params; //flag to indicate to force parameter (LFO) update & sample update on first run
    
LV2_Handle init_phaselv2()
    plug->init_params = 1; // LFO init
    
void run_phaselv2()
    //LFO effects require period be set before setting other params
    if(plug->init_params)
    {
        plug->phase->PERIOD = nframes;
        plug->phase->lfo->updateparams(nframes);
        plug->init_params = 0; // so we only do this once
    }
    
The bug is the result of the best guess init below which is used for any plugin which uses the EffectLFO() class.
    PERIOD = 256; //make best guess for init;
    
The problems occurs when the initial default ttl parameter settings, or the setpreset() gets set before the plugin is actually run, using the guess value of 256. Then when the plug is run, the PERIOD gets updated, but the lfo->updateparams does not since there is no parameter adjustment to trigger it. 

Only occurs when the host, or jack Frames/Period is different than the guess of 256, and the user preset is the same for all default parameters set by setpreset() that trigger lfo->updateparams.

The easiest way to experience the bug is with Alienwah. Set jack Frames/Period to 1024 and run 
Alienwah with the default settings in jalv. Connect a clean guitar sound to the plug and listen. Then change one of the parameter's sliders that trigger the lfo->updateparams, such as Tempo and reset it back to the default value. Then listen again and you will notice a significant difference in the effect.

If my proposed solution to the bug is acceptable, I can push to you the fixes for the other plugins that may be affected by the bug. Or if prefer a different solution, I can do that as well.