### PR TITLE
Vibe -- fix undefined behavior, gargabe output

### DIFF
--- a/src/Vibe.C
+++ b/src/Vibe.C
@@ -86,8 +86,19 @@ Vibe::~Vibe ()
 void
 Vibe::cleanup ()
 {
+    /* also used after bypass to reset filter state */
+    for (int i = 0; i < 8; ++i) {
+        vc[i].clear ();
+        vcvo[i].clear ();
+        ecvc[i].clear ();
+        vevo[i].clear ();
+        bootstrap[i].clear ();
+    }
 
-
+    /* should probably reset modulation state here,
+     * but Vibe::cleanup is currently called periodically
+     * on every bypass call. -- That need fixing first.
+     */
 };
 
 void
@@ -298,7 +309,7 @@ Vibe::out (float *smpsl, float *smpsr, uint32_t period)
 };
 
 float
-Vibe::vibefilter(float data, fparams *ftype, int stage)
+Vibe::vibefilter(float data, fparams *ftype, int stage) const
 {
     float y0 = 0.0f;
     y0 = data*ftype[stage].n0 + ftype[stage].x1*ftype[stage].n1 - ftype[stage].y1*ftype[stage].d1;
@@ -308,7 +319,7 @@ Vibe::vibefilter(float data, fparams *ftype, int stage)
 };
 
 float
-Vibe::bjt_shape(float data)
+Vibe::bjt_shape(float data) const
 {
     float vbe, vout;
     float vin = 7.5f*(1.0f + data);

--- a/src/Vibe.h
+++ b/src/Vibe.h
@@ -80,6 +80,14 @@ private:
     class fparams
     {
     public:
+        fparams () {
+            clear ();
+            n0 = n1 = d0 = d1 = 0;
+        }
+        void clear () {
+            x1 = y1 = 0;
+        }
+        //filter state
         float x1;
         float y1;
         //filter coefficients
@@ -89,10 +97,10 @@ private:
         float d1;
     } vc[8], vcvo[8], ecvc[8], vevo[8], bootstrap[8];
 
-    float vibefilter(float data, fparams *ftype, int stage);
+    float vibefilter(float data, fparams *ftype, int stage) const;
     void init_vibes();
     void modulate(float ldrl, float ldrr);
-    float bjt_shape(float data);
+    float bjt_shape(float data) const;
 
     float R1;
     float Rv;


### PR DESCRIPTION
Ideally apply on top of #36 

This fixes various issues with rkr-vibe due to uninitialized variables in the filters.
Depending on the initial state, it may produce constant garbage output and even NaN or Inf.