### PR TITLE
lv2: enable -msse flags on x86 arch only

### DIFF
--- a/lv2/CMakeLists.txt
+++ b/lv2/CMakeLists.txt
@@ -5,9 +5,10 @@ cmake_minimum_required(VERSION 2.6)
 project (rkrlv2)
 
 set(LV2_INSTALL_DIR lib/lv2/rkr.lv2 ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
-IF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+
+IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|X86|amd64|AMD64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -msse -msse2 -mfpmath=sse -ffast-math")
-ENDIF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+ENDIF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|X86|amd64|AMD64")
 
 # check for our various libraries
 find_package(PkgConfig)


### PR DESCRIPTION
For odroid-c2 board, the system architecture is "aarch64" instead of "arm". The proposal is to apply -msse flags only on x86 arch.
On my system, this is working properly, my system is detected by "x86_64" and matches the expression "x86|X86|amd64|AMD64".

I read that, in the worst case, the detected system is "Unknown". In that case, this is preferable to avoid "-msse" flags too.

The idea for the solution: https://stackoverflow.com/a/26662907

Where the issue was found for reference: https://github.com/auto3000/meta-pedalpi/issues/42